### PR TITLE
Fix Windows release build by gating Unix-only code with cfg(unix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ zune-bmp = "0.4"
 zune-image = { version = "0.4", default-features = false, features = ["jpeg", "png", "bmp", "metadata"] }
 gif = "0.14"
 image-webp = "0.2"
-libc = "0.2"
-users = "0.11"
 png = "0.17"
 exif = { package = "kamadak-exif", version = "0.5.5" }
 zip = { version = "0.6", default-features = false, features = ["deflate", "time"] }
@@ -39,3 +37,7 @@ winit = "0.30.5"
 once_cell = "1.19"
 syntect = "5"
 memchr = "2.7"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+users = "0.11"

--- a/src/input.rs
+++ b/src/input.rs
@@ -355,6 +355,7 @@ pub(crate) fn handle_keyboard(
         }
     }
     let alt_enter = ctx.input_mut(|i| i.consume_key(egui::Modifiers::ALT, egui::Key::Enter));
+    #[cfg(unix)]
     if alt_enter {
         open_props_dialog(app);
         ctx.request_repaint();

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,13 @@ use std::{
     fs,
     hash::{Hash, Hasher},
     io::Read,
-    os::unix::fs::{FileTypeExt, MetadataExt},
     path::{Path, PathBuf},
     sync::{Arc, mpsc},
     thread,
     time::UNIX_EPOCH,
 };
+#[cfg(unix)]
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 
 mod image_decode;
 mod input;
@@ -2021,6 +2022,7 @@ fn reload_panel(app: &mut app_state::AppState, which: core::ActivePanel) {
     }
 }
 
+#[cfg(unix)]
 fn open_props_dialog(app: &mut app_state::AppState) {
     let panel = app.get_active_panel();
     let browser = &panel.browser;
@@ -2076,6 +2078,7 @@ fn open_props_dialog(app: &mut app_state::AppState) {
     });
 }
 
+#[cfg(unix)]
 fn file_type_label(meta: &std::fs::Metadata) -> String {
     let file_type = meta.file_type();
     if file_type.is_dir() {
@@ -2808,6 +2811,7 @@ impl winit::application::ApplicationHandler<UserEvent> for App {
                     {
                         ui::modals::draw_discard_modal(ctx, &mut runtime.app);
                     }
+                    #[cfg(unix)]
                     if runtime.app.props_dialog.is_some() {
                         ui::props_dialog::draw_props_modal(ctx, &mut runtime.app);
                     }
@@ -3212,6 +3216,7 @@ fn draw_root_ui(render: UiRender<'_>) {
     {
         ui::modals::draw_discard_modal(ctx, app);
     }
+    #[cfg(unix)]
     if app.props_dialog.is_some() {
         ui::props_dialog::draw_props_modal(ctx, app);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,5 +4,6 @@ pub mod help;
 pub mod modals;
 pub mod panel;
 pub mod preview;
+#[cfg(unix)]
 pub mod props_dialog;
 pub mod theme_picker;

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1,4 +1,6 @@
+#[cfg(unix)]
 use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
     fs::File,
@@ -125,6 +127,7 @@ pub fn start_io_worker() -> (
                         eprintln!("Mkdir error: {e}");
                     }
                 }
+                #[cfg(unix)]
                 IOTask::SetProps {
                     path,
                     mode,
@@ -141,6 +144,10 @@ pub fn start_io_worker() -> (
                         eprintln!("Props error: {e}");
                     }
                 }
+                #[cfg(not(unix))]
+                IOTask::SetProps { .. } => {
+                    eprintln!("SetProps is not supported on this platform");
+                }
             }
             let _ = result_tx.send(IOResult::Completed);
         }
@@ -148,6 +155,7 @@ pub fn start_io_worker() -> (
     (tx, result_rx, cancel_tx)
 }
 
+#[cfg(unix)]
 fn apply_props(path: &Path, mode: u32, uid: u32, gid: u32) -> std::io::Result<()> {
     let permissions = std::fs::Permissions::from_mode(mode);
     std::fs::set_permissions(path, permissions)?;
@@ -158,6 +166,7 @@ fn apply_props(path: &Path, mode: u32, uid: u32, gid: u32) -> std::io::Result<()
     Ok(())
 }
 
+#[cfg(unix)]
 fn apply_props_recursive(path: &Path, mode: u32, uid: u32, gid: u32) -> std::io::Result<()> {
     let meta = std::fs::symlink_metadata(path)?;
     if meta.file_type().is_symlink() {


### PR DESCRIPTION
Move `libc` and `users` crates to `[target.'cfg(unix)'.dependencies]`
and add `#[cfg(unix)]` gates around all Unix-specific APIs:
`std::os::unix` imports, `users` crate calls, `libc::chown`, and the
properties dialog UI that depends on them.

https://claude.ai/code/session_017p34U1gzAd9tzXGjacctYq