### PR TITLE
Reserve enough output room in preview decoder

### DIFF
--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1135,7 +1135,13 @@ fn send_streaming_preview<R: Read>(
                 encoding.new_decoder_without_bom_handling()
             });
             let last = remaining == 0;
-            let mut text = String::with_capacity(chunk.len() + 16);
+            // A single input byte can expand to up to 3 UTF-8 output bytes
+            // (Cyrillic in CP1251, CJK in various single-byte encodings, …).
+            // Reserving max_utf8_buffer_length avoids OutputFull truncation.
+            let cap = dec
+                .max_utf8_buffer_length(chunk.len())
+                .unwrap_or(chunk.len() * 3);
+            let mut text = String::with_capacity(cap);
             let _ = dec.decode_to_string(chunk, &mut text, last);
             let _ = tx.send((
                 id,


### PR DESCRIPTION
Streaming preview allocated capacity = chunk.len() + 16 for the decoded String. For encodings whose bytes expand under UTF-8 — one CP1251 Cyrillic byte becomes two UTF-8 bytes, one Shift_JIS byte can become three — that ran out mid-chunk and decode_to_string returned OutputFull. The unused result meant every such preview was silently cut short (e.g. a 700-byte CP1251 file ended a couple of hundred bytes early).

Reserve max_utf8_buffer_length up front instead so the whole chunk fits.