### PR TITLE
Stop unconditional repaint on image preview

### DIFF
--- a/src/ui/preview.rs
+++ b/src/ui/preview.rs
@@ -565,7 +565,6 @@ pub fn draw_preview(ui: &mut egui::Ui, ctx: PreviewRender<'_>) {
                                             preview.image_pan = [0.0, 0.0];
                                             ui.add(egui::Image::new(sized).fit_to_exact_size(size));
                                         }
-                                        ui.ctx().request_repaint();
                                     } else {
                                         if image_cache.pending.insert(key.clone()) {
                                             let _ = image_req_tx.send(request);


### PR DESCRIPTION
A static image doesn't need continuous repainting; the animation and refining branches already schedule their own request_repaint_after. The unconditional request_repaint pinned CPU at full frame rate whenever any image preview was visible.