### PR TITLE
Don't scan zip local headers to list archives

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -5,7 +5,7 @@ use std::{
     path::{self, Path},
 };
 
-use crate::core::{DirEntry, EntryLocation, format_mode, format_size};
+use crate::core::{DirEntry, EntryLocation, format_size};
 
 const ARCHIVE_READ_BUFFER: usize = 1024 * 1024;
 
@@ -22,11 +22,15 @@ where
         let locked = session
             .lock()
             .map_err(|_| io::Error::other("session mutex poisoned"))?;
-        let mut file = locked
+        let file = locked
             .sftp
             .open(Path::new(&remote_path))
             .map_err(|e| io::Error::other(format!("open remote {remote_path}: {e}")))?;
-        f(&mut file)
+        // Buffer the remote handle: the zip reader parses the central directory
+        // with many tiny field-sized reads, and each unbuffered read is a
+        // separate SFTP round-trip. Buffering collapses them into 1 MB fills.
+        let mut reader = io::BufReader::with_capacity(ARCHIVE_READ_BUFFER, file);
+        f(&mut reader)
     } else {
         let file = fs::File::open(archive_path)?;
         let mut reader = io::BufReader::with_capacity(ARCHIVE_READ_BUFFER, file);
@@ -380,7 +384,7 @@ fn copy_tar_dir<R: Read>(reader: R, inner_path: &str, dst_root: &Path) -> io::Re
 
 fn read_zip_directory(archive_path: &Path, cwd: &str) -> anyhow::Result<Vec<DirEntry>> {
     let (dirs, files) = with_seek_reader(archive_path, |reader| {
-        let mut zip = zip::ZipArchive::new(reader).map_err(io::Error::other)?;
+        let zip = zip::ZipArchive::new(reader).map_err(io::Error::other)?;
         let mut dirs: Vec<String> = Vec::new();
         let mut seen_dirs: HashSet<String> = HashSet::new();
         let mut files: Vec<String> = Vec::new();
@@ -392,12 +396,10 @@ fn read_zip_directory(archive_path: &Path, cwd: &str) -> anyhow::Result<Vec<DirE
             format!("{}/", cwd.trim_end_matches('/'))
         };
 
-        for i in 0..zip.len() {
-            let name = zip
-                .by_index(i)
-                .map_err(io::Error::other)?
-                .name()
-                .to_string();
+        // Names come straight from the in-memory central directory. Using
+        // by_index() here would seek to each entry's local header — one SFTP
+        // round-trip per entry — which is ruinous for a large remote archive.
+        for name in zip.file_names() {
             if name.is_empty() || !name.starts_with(&prefix) {
                 continue;
             }
@@ -501,12 +503,7 @@ fn read_zip_directory(archive_path: &Path, cwd: &str) -> anyhow::Result<Vec<DirE
     Ok(entries)
 }
 
-pub fn format_container_listing(
-    kind: ContainerKind,
-    archive_path: &Path,
-    entries: &[DirEntry],
-    max_entries: usize,
-) -> String {
+pub fn format_container_listing(entries: &[DirEntry], max_entries: usize) -> String {
     let mut out = String::new();
     out.push_str("Contents:\n");
     let mut count = 0usize;
@@ -521,26 +518,18 @@ pub fn format_container_listing(
             ));
             break;
         }
-        let size = read_container_metadata(kind, archive_path, entry_name_for_metadata(entry))
-            .ok()
-            .flatten()
-            .map(|(size, mode)| (format_size(size), mode));
-        let mode_str = size.as_ref().and_then(|pair| pair.1.map(format_mode));
-        let size_str = size.as_ref().map(|pair| pair.0.as_str());
-
+        // Render straight from the already-loaded listing. Previously this
+        // re-opened the whole archive once per entry to fetch a size — for a
+        // large (especially remote) archive that meant reopening and scanning
+        // the central directory hundreds of times, holding the SFTP session
+        // lock throughout. The size shown here isn't worth that; use whatever
+        // the listing already carries.
         let mut line = String::new();
-        if let Some(mode) = mode_str {
-            line.push_str(&mode);
-            line.push(' ');
+        if let Some(size) = entry.size {
+            line.push_str(&format!("{:>8} ", format_size(size)));
         } else {
-            line.push_str("---- ");
+            line.push_str("       - ");
         }
-        if let Some(size) = size_str {
-            line.push_str(size);
-        } else {
-            line.push_str("    -");
-        }
-        line.push(' ');
         line.push_str(&entry_display_name(entry));
         line.push('\n');
         out.push_str(&line);
@@ -554,14 +543,6 @@ fn entry_display_name(entry: &DirEntry) -> String {
         format!("{}/", entry.name)
     } else {
         entry.name.clone()
-    }
-}
-
-fn entry_name_for_metadata(entry: &DirEntry) -> &str {
-    if entry.is_dir {
-        entry.name.trim_end_matches('/')
-    } else {
-        entry.name.as_str()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1586,8 +1586,26 @@ fn draw_elevation_modal(ctx: &egui::Context, message: &str) -> Option<bool> {
 
 fn draw_async_indicator(ctx: &egui::Context, app: &app_state::AppState) {
     let search_running = matches!(app.search_status, app_state::SearchStatus::Running(_));
+    // Largest entry count among archives still being indexed, if any. Gives the
+    // user a live "still working" signal — a big remote archive can take a
+    // while to stream in, and without this the panel would look frozen/empty.
+    let indexing_count = [core::ActivePanel::Left, core::ActivePanel::Right]
+        .into_iter()
+        .filter_map(|side| {
+            let archive = app.panel(side).browser().watching_archive.as_ref()?;
+            let shared = app.archive_index.get(archive)?;
+            Some(
+                shared
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .entries
+                    .len(),
+            )
+        })
+        .max();
     let is_busy = app.io_in_flight > 0
         || search_running
+        || indexing_count.is_some()
         || !app.dir_size_pending.is_empty()
         || !app.remote_dir_size_pending.is_empty();
     if !is_busy {
@@ -1601,6 +1619,9 @@ fn draw_async_indicator(ctx: &egui::Context, app: &app_state::AppState) {
     }
     if search_running {
         label += " scan";
+    }
+    if let Some(count) = indexing_count {
+        label += &format!(" {count} indexed");
     }
     let sz_pending = app.dir_size_pending.len() + app.remote_dir_size_pending.len();
     if sz_pending > 0 {
@@ -2607,6 +2628,15 @@ fn load_container_directory_async(
             }
 
             let indexing_result: std::io::Result<()> = if kind_clone == core::ContainerKind::Zip {
+                // A zip's central directory (parsed once by ZipArchive::new)
+                // already holds every entry's name, so listing needs no
+                // per-entry I/O. Uncompressed *size*, however, is only exposed
+                // through by_index(), which seeks to each entry's local header —
+                // one network round-trip per entry over SFTP, i.e. minutes for a
+                // large remote archive. So fetch sizes only for local files,
+                // where the seek hits the OS page cache; for remote archives we
+                // list from the central directory alone and leave size unknown.
+                let is_remote = fileman::sftp::decode_archive_path(&archive_clone).is_some();
                 fileman::archive::with_seek_reader(&archive_clone, |reader| {
                     let mut zip = zip::ZipArchive::new(reader).map_err(std::io::Error::other)?;
                     // Pre-scan all entry names to detect root (cheap — central
@@ -2632,20 +2662,23 @@ fn load_container_directory_async(
                     implicit_root = decide_root(&root_candidate, seen_root_file, seen_other_root);
 
                     for i in 0..zip.len() {
-                        let entry = match zip.by_index(i) {
-                            Ok(entry) => entry,
-                            Err(_) => continue,
+                        // name_for_index reads the in-memory central directory,
+                        // no seek. Derive everything owned from it before the
+                        // reader is borrowed again for the optional size lookup.
+                        let Some(raw_name) = zip.name_for_index(i) else {
+                            continue;
                         };
-                        let entry_is_dir = entry.is_dir();
-                        let entry_size = if entry_is_dir {
-                            None
-                        } else {
-                            Some(entry.size())
-                        };
-                        let name = core::normalize_archive_path(Path::new(entry.name()));
+                        let entry_is_dir = raw_name.ends_with('/') || raw_name.ends_with('\\');
+                        let name = core::normalize_archive_path(Path::new(raw_name));
                         if name.is_empty() {
                             continue;
                         }
+                        let entry_size = if entry_is_dir || is_remote {
+                            None
+                        } else {
+                            // Local only: seek to the local header for the size.
+                            zip.by_index(i).ok().map(|entry| entry.size())
+                        };
 
                         batch_buf.push((name, entry_is_dir, entry_size));
                         if batch_buf.len() >= BATCH {

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -1025,8 +1025,7 @@ pub fn start_preview_worker(
                             continue;
                         }
                     };
-                    let listing =
-                        format_container_listing(kind, &archive_path, &entries, max_entries);
+                    let listing = format_container_listing(&entries, max_entries);
                     let _ = result_tx.send((id, PreviewContent::Text(listing)));
                 }
             }


### PR DESCRIPTION
Listing a zip only needs its central directory, which ZipArchive::new parses in one pass. But the loaders were reading per-entry uncompressed size via by_index(), which seeks to each entry's local header — one round-trip per entry. For a 90k-entry archive that's ~2s locally and minutes over SFTP, during which the shared SFTP session lock is held, freezing every other operation on that host (including navigating back out). This is why a large remote zip showed nothing and got stuck on exit.

- Streaming index + read_zip_directory now list from the central directory (name_for_index / file_names, no seek). Per-entry size is fetched only for local archives, where the local-header seek hits the page cache; remote archives list instantly with size left unknown.
- format_container_listing rendered the archive-contents preview by reopening the whole archive once per entry (hundreds of central-dir reparses under the session lock). It now renders from the already loaded listing — microseconds instead of minutes.
- Buffer the remote SFTP handle so ZipArchive::new's many tiny central-directory reads batch into 1 MB fills instead of a round-trip per field.
- Show a live "N indexed" counter in the async indicator while an archive is still streaming in, so a slow load no longer looks frozen.